### PR TITLE
Improve dist.ini to fix a CPANTS warning

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,8 +2,11 @@ Revision history for Dancer-Plugin-Auth-Basic
 
 {{$NEXT}}
 
+0.031     2015-03-01
+          * CPANTS has-readme warning fix
+          
 0.030     2014-04-14
-          Switched to using Dist::Zilla.
+          * Switched to using Dist::Zilla.
 
 0.02      2012-06-25
           * Added support for encrypted passwords in configuration files
@@ -19,4 +22,4 @@ Revision history for Dancer-Plugin-Auth-Basic
           * Added missing requirements to build script
 
 0.01      2011-10-06
-          First version, released on an unsuspecting world.
+          * First version, released on an unsuspecting world.

--- a/README.pod
+++ b/README.pod
@@ -8,7 +8,7 @@ Dancer::Plugin::Auth::Basic - Basic HTTP authentication for Dancer web apps
 
 =head1 VERSION
 
-version 0.030
+version 0.031
 
 =head1 SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -8,3 +8,5 @@ copyright_year   = 2011
 git_remote = github
 stopwords = Miyagawa
 stopwords = Tatsuhiko
+
+[Readme]


### PR DESCRIPTION
The mentioned warning can be seen at http://cpants.cpanauthors.org/dist/Dancer-Plugin-Auth-Basic
It's obviously not an urgent (or even necessary) fix, yet I wanted to contribute (even small) as part of CPAN PR Challenge.

I was advised on pr-challenge dedicated IRC channel that adding a simple [Readme] to the end of dist.ini would fix the issue, hence the PR. I've seen ReadmeAnyFromPod / ReadmePodInRoot in your Dist Zilla Plugin Bundle, but either (a) it was not considered as a readme by CPANTS or (b) files you have uploaded to CPAN did miss a readme file, unlike GitHub repo (which has a great readme).

To note it again, as the warning is not crucial, this contribution may not be very constructive. There might even be simpler solutions to the noted warning.
