### PR TITLE
Limit split() so passwords with colons work

### DIFF
--- a/lib/Dancer/Plugin/Auth/Basic.pm
+++ b/lib/Dancer/Plugin/Auth/Basic.pm
@@ -73,7 +73,7 @@ sub _auth_basic {
     my $authorized = undef;
     
     if (defined $auth && $auth =~ /^Basic (.*)$/) {
-        my ($user, $password) = split(/:/, (MIME::Base64::decode($1) || ":"));
+        my ($user, $password) = split(/:/, (MIME::Base64::decode($1) || ":"), 2);
         
         if (exists $options{user}) {
             # A single user is defined


### PR DESCRIPTION
HTTP basic auth usernames can't contain colons, but passwords can, so
limit the split() to 2 so that a password with a colon will work.
